### PR TITLE
feat songs url

### DIFF
--- a/core/backend/src/application/music/like.rs
+++ b/core/backend/src/application/music/like.rs
@@ -77,7 +77,6 @@ pub async fn like_list(
     }))
 }
 
-
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct LikeSongReq {
     pub source: MusicSource,
@@ -86,18 +85,27 @@ pub struct LikeSongReq {
 }
 
 #[tauri::command]
-pub async fn like_song(
-    req: LikeSongReq,
-) -> Result<ApplicationResp<bool>, InvokeError> {
+pub async fn like_song(req: LikeSongReq) -> Result<ApplicationResp<bool>, InvokeError> {
     let mut instance = INSTANCE.write().await;
 
     match req.source {
         MusicSource::Netesae => {
-            let result = instance.netesae.client().like_song(req.song_id, req.is_like).await.map_err(InvokeError::from_anyhow)?;
+            let result = instance
+                .netesae
+                .client()
+                .like_song(req.song_id, req.is_like)
+                .await
+                .map_err(InvokeError::from_anyhow)?;
             Ok(ApplicationResp::success_data(result))
         }
-        MusicSource::Spotify => {todo!()}
-        MusicSource::QQ => {todo!()}
-        MusicSource::Apple => {todo!()}
+        MusicSource::Spotify => {
+            todo!()
+        }
+        MusicSource::QQ => {
+            todo!()
+        }
+        MusicSource::Apple => {
+            todo!()
+        }
     }
 }

--- a/core/backend/src/application/music/mod.rs
+++ b/core/backend/src/application/music/mod.rs
@@ -1,1 +1,2 @@
 pub mod like;
+pub mod song;

--- a/core/backend/src/application/music/song.rs
+++ b/core/backend/src/application/music/song.rs
@@ -1,0 +1,49 @@
+use crate::application::resp::ApplicationResp;
+use crate::application::MusicSource;
+use crate::types::song_url::{SongRate, SongUrl};
+use crate::INSTANCE;
+use serde::{Deserialize, Serialize};
+use std::fmt::Debug;
+use tauri::ipc::InvokeError;
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct SongsUrlReq {
+    pub source: MusicSource,
+    pub songs: Vec<u64>,
+    pub rate: SongRate,
+}
+
+#[derive(Serialize, Debug, Clone)]
+pub struct SongsUrlResp<T: Serialize + Clone + Debug> {
+    pub urls: Vec<T>,
+}
+
+#[tauri::command]
+pub async fn songs_url(
+    req: SongsUrlReq,
+) -> Result<ApplicationResp<SongsUrlResp<SongUrl>>, InvokeError> {
+    let mut instance = INSTANCE.write().await;
+
+    let list = match req.source {
+        MusicSource::Netesae => {
+            let result = instance
+                .netesae
+                .client()
+                .songs_url(&req.songs, req.rate)
+                .await
+                .map_err(InvokeError::from_anyhow)?;
+            result
+        }
+        MusicSource::Spotify => {
+            todo!()
+        }
+        MusicSource::QQ => {
+            todo!()
+        }
+        MusicSource::Apple => {
+            todo!()
+        }
+    };
+
+    Ok(ApplicationResp::success_data(SongsUrlResp { urls: list }))
+}

--- a/core/backend/src/music_client/mod.rs
+++ b/core/backend/src/music_client/mod.rs
@@ -3,6 +3,7 @@ pub mod impls;
 use crate::types::login_info::{LoginInfo, LoginQrInfo};
 use crate::types::play_list_info::PlayListInfo;
 use crate::types::song_info::SongInfo;
+use crate::types::song_url::{SongRate, SongUrl};
 use anyhow::Result;
 use async_trait::async_trait;
 
@@ -21,4 +22,6 @@ pub trait Client: Sync + Send {
     async fn search_song(&mut self, song: &str, singer: &str) -> Result<Option<SongInfo>>;
 
     async fn like_song(&mut self, song_id: u64, is_like: bool) -> Result<bool>;
+
+    async fn songs_url(&mut self, songs: &[u64], song_rate: SongRate) -> Result<Vec<SongUrl>>;
 }

--- a/core/backend/src/types/mod.rs
+++ b/core/backend/src/types/mod.rs
@@ -4,3 +4,4 @@ pub mod error;
 pub mod login_info;
 pub mod play_list_info;
 pub mod song_info;
+pub mod song_url;

--- a/core/backend/src/types/song_url.rs
+++ b/core/backend/src/types/song_url.rs
@@ -1,0 +1,29 @@
+use ncm_api::SongUrl as NcSongUrl;
+use serde::{Deserialize, Serialize};
+use strum_macros::Display;
+
+#[derive(Serialize, Deserialize, Debug, Clone, Display)]
+pub enum SongRate {
+    #[strum(serialize = "128000")]
+    L,
+    #[strum(serialize = "192000")]
+    M,
+    #[strum(serialize = "320000")]
+    H,
+    #[strum(serialize = "999000")]
+    SQ,
+    #[strum(serialize = "1900000")]
+    HR,
+}
+
+#[derive(Serialize, Debug, Clone)]
+#[serde(tag = "type", content = "content")]
+pub enum SongUrlData {
+    Netesae(NcSongUrl),
+}
+
+#[derive(Serialize, Debug, Clone)]
+pub struct SongUrl {
+    #[serde(flatten)]
+    pub data: SongUrlData,
+}


### PR DESCRIPTION
# 音乐客户端功能
测试结果如图
1. 根据歌曲id列表获取歌曲url
![image](https://github.com/user-attachments/assets/2fd3d17e-577d-4fe9-815b-1b2c35864b2f)

# 后端接口
## 根据歌曲id列表返回歌曲url
```jsonc

rate(歌曲码率,从左到右变高): L(128000), M(192000), H(320000), SQ(999000), HR(1900000)

req: 
{
	"source": "Netesae",
	"songs": [480097437],
	"rate": "L",
}

resp:
{
  "code": 0,
  "msg": "",
  "data": {
    "urls": [
      {
        "type": "Netesae",
        "content": {
          "id": 480097437,
          "url": "http://m7.music.126.net/20241122160514/9f8c99100af6c97b5d23ba069704a368/ymusic/58d0/bbb4/1f59/3b1caa8b4e3c79783d8dfcf613feb5e1.mp3",
          "rate": 128000
        }
      }
    ]
  }
}
```